### PR TITLE
Fix save3ds_fuse link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rebuild-title-database
 Rebuilds the contents of `title.db` for Nintendo 3DS.
 
-This currently does not interact with `title.db` directly, [https://github.com/wwylele/save3ds](save3ds_fuse) must be used manually to extract and rebuild.
+This currently does not interact with `title.db` directly, [save3ds_fuse](https://github.com/wwylele/save3ds) must be used manually to extract and rebuild.
 
 This had minimal testing, but it probably works in most cases. File an issue, send me an email, or contact me on Discord if there are problems.
 


### PR DESCRIPTION
Markdown format was swapped so it was showing the link as the name and the name as the link. Confused me for a second.